### PR TITLE
Get thumb 120 from package

### DIFF
--- a/lib/SSpkS/Package/Package.php
+++ b/lib/SSpkS/Package/Package.php
@@ -254,6 +254,16 @@ class Package
      */
     public function getSnapshots($pathPrefix = '')
     {
+        /* Let's first try to extract screenshots from package (SSpkS feature) */
+        $i = 1;
+        while (true) {
+            try {
+                $this->extractIfMissing('screen_' . $i . '.png', $this->filepathNoExt . '_screen_' . $i . '.png');
+                $i++;
+            } catch (\Exception $e) {
+                break;
+            }
+        }
         $snapshots = array();
         // Add screenshots, if available
         foreach (glob($this->filepathNoExt . '*_screen_*.png') as $snapshot) {

--- a/lib/SSpkS/Package/Package.php
+++ b/lib/SSpkS/Package/Package.php
@@ -223,6 +223,16 @@ class Package
                 file_put_contents($this->filepathNoExt . '_thumb_72.png', base64_decode($this->metadata['package_icon']));
             }
         }
+        /* Synology itself uses 256x256 img for the 120 thumb (see the Calendar package) */
+        try {
+            $this->extractIfMissing('PACKAGE_ICON_256.PNG', $this->filepathNoExt . '_thumb_120.png');
+        } catch (\Exception $e) {
+            // Check if icon is in metadata
+            $this->collectMetadata();
+            if (isset($this->metadata['package_icon_256'])) {
+                file_put_contents($this->filepathNoExt . '_thumb_120.png', base64_decode($this->metadata['package_icon_256']));
+            }
+        }
         $thumbnails = array();
         foreach (array('72', '120') as $size) {
             $thumb_name = $this->filepathNoExt . '_thumb_' . $size . '.png';


### PR DESCRIPTION
Hello,

This PR extracts thumb 120 image from the package itself, so that we don't have to generate it ourselves.
Note that I use the 256x256 package icon for this, which is what Synology also does.

Thank you 👍 

Ben