### PR TITLE
Solve UTF-8 encoding issue

### DIFF
--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -154,6 +154,6 @@ auto_upgrade_from - version number (optional)
             $jsonOutput['keyrings'] = $keyring;
         }
 
-        echo stripslashes(json_encode($jsonOutput));
+        echo stripslashes(json_encode($jsonOutput, JSON_UNESCAPED_UNICODE));
     }
 }


### PR DESCRIPTION
Hello,

This PR solves an issue when INFO file contains UTF-8 characters.
Output is not correct, for example `u00e9` instead of `é`.

This PR solves this bug.

Thank you 👍 

Ben