### PR TITLE
Make Quick Inst enabled by default

### DIFF
--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -107,9 +107,9 @@ auto_upgrade_from - version number (optional)
             'thumbnail'    => $pkg->thumbnail_url,
             'snapshot'     => $pkg->snapshot_url,
             // quick install/start/upgrade
-            'qinst'        => $this->ifEmpty($pkg, 'qinst', false),
-            'qstart'       => $this->ifEmpty($pkg, 'start', false),
-            'qupgrade'     => $this->ifEmpty($pkg, 'qupgrade', false),
+            'qinst'        => $this->ifEmpty($pkg, 'qinst', true),
+            'qstart'       => $this->ifEmpty($pkg, 'start', true),
+            'qupgrade'     => $this->ifEmpty($pkg, 'qupgrade', true),
             'depsers'      => $this->ifEmpty($pkg, 'start_dep_services'), // required started packages
             'deppkgs'      => $deppkgs,
             'conflictpkgs' => null,

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -64,7 +64,7 @@ class JsonOutputTest extends TestCase
             'gives you the ability to run thousands of containers created by developers from all over the world on DSM. The hugely popular built-in image repository, Docker ' .
             'Hub, allows you to find shared applications from other talented developers.","price":0,"download_count":6000,"recent_download_count":1222,"link":"http://prefix' . $this->tempPkg .
             '","size":' . $pkgSize . ',"md5":"' . $pkgMd5 . '","thumbnail":["http://prefix' . $p->thumbnail[0] . '","http://prefix' . $p->thumbnail[1] . '"],' .
-            '"snapshot":["http://prefix' . $p->snapshot[0] . '","http://prefix' . $p->snapshot[1] . '"],"qinst":false,"qstart":false,"qupgrade":false,"depsers":null,"deppkgs"' .
+            '"snapshot":["http://prefix' . $p->snapshot[0] . '","http://prefix' . $p->snapshot[1] . '"],"qinst":true,"qstart":true,"qupgrade":true,"depsers":null,"deppkgs"' .
             ':null,"conflictpkgs":null,"start":true,"maintainer":"Synology Inc.","maintainer_url":"http://dummy.org/","distributor":"SSpkS","distributor_url":"http://dummy.org/",' .
             '"changelog":"","thirdparty":true,"category":0,"subcategory":0,"type":0,"silent_install":true,"silent_uninstall":true,"silent_upgrade":true,"beta":false}],"keyrings":["test\n12345"]}'
         );


### PR DESCRIPTION
Hello,

If quick installation is not enabled, and we don't have a WIZARD_UIFILES directory in the package, a default wizard appears in the background, whereas installation is processing...
When installation is finished, wizard is still displaying, which does not make sense...

This PR then avoids this.
Note that quick installation is enabled for almost all Synology packages.

Thank you 👍 

Ben