### PR TITLE
Allow empty maintainer and distributor

### DIFF
--- a/conf/sspks.yaml
+++ b/conf/sspks.yaml
@@ -2,6 +2,12 @@ site:
     name: Simple SPK Server
     theme: material
 
+packages:
+    maintainer:
+    maintainer_url:
+    distributor:
+    distributor_url:
+
 # ALL PATHS MUST BE RELATIVE TO THE ROOT
 # DIRECTORY (where the index.php is located)
 # INCLUDE TRAILING SLASH FOR DIRECTORIES!

--- a/conf/sspks.yaml
+++ b/conf/sspks.yaml
@@ -3,10 +3,10 @@ site:
     theme: material
 
 packages:
-    maintainer:
-    maintainer_url:
-    distributor:
-    distributor_url:
+    maintainer: ""
+    maintainer_url: ""
+    distributor: ""
+    distributor_url: ""
 
 # ALL PATHS MUST BE RELATIVE TO THE ROOT
 # DIRECTORY (where the index.php is located)

--- a/lib/SSpkS/Handler/SynologyHandler.php
+++ b/lib/SSpkS/Handler/SynologyHandler.php
@@ -63,7 +63,7 @@ class SynologyHandler extends AbstractHandler
         $uf = new UrlFixer($this->config->baseUrl);
         $uf->fixPackageList($filteredPkgList);
 
-        $jo = new JsonOutput();
+        $jo = new JsonOutput(this->config);
         $jo->setExcludedServices($this->config->excludedSynoServices);
         $jo->outputPackages($filteredPkgList);
     }

--- a/lib/SSpkS/Handler/SynologyHandler.php
+++ b/lib/SSpkS/Handler/SynologyHandler.php
@@ -63,7 +63,7 @@ class SynologyHandler extends AbstractHandler
         $uf = new UrlFixer($this->config->baseUrl);
         $uf->fixPackageList($filteredPkgList);
 
-        $jo = new JsonOutput(this->config);
+        $jo = new JsonOutput($this->config);
         $jo->setExcludedServices($this->config->excludedSynoServices);
         $jo->outputPackages($filteredPkgList);
     }

--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -39,6 +39,13 @@ class JsonOutput
         }
         return $alternative;
     }
+    private function ifUnset($obj, $property, $alternative = null)
+    {
+        if (isset($obj->$property)) {
+            return $obj->$property;
+        }
+        return $alternative;
+    }
 
     /**
      * Returns JSON-ready array of Package $pkg.
@@ -114,10 +121,10 @@ auto_upgrade_from - version number (optional)
             'deppkgs'      => $deppkgs,
             'conflictpkgs' => null,
             'start'        => true,
-            'maintainer'      => $this->ifEmpty($pkg, 'maintainer', 'SSpkS'),
-            'maintainer_url'  => $this->ifEmpty($pkg, 'maintainer_url', 'http://dummy.org/'),
-            'distributor'     => $this->ifEmpty($pkg, 'distributor', 'SSpkS'),
-            'distributor_url' => $this->ifEmpty($pkg, 'distributor_url', 'http://dummy.org/'),
+            'maintainer'      => $this->ifUnset($pkg, 'maintainer', 'SSpkS'),
+            'maintainer_url'  => $this->ifUnset($pkg, 'maintainer_url', 'http://dummy.org/'),
+            'distributor'     => $this->ifUnset($pkg, 'distributor', 'SSpkS'),
+            'distributor_url' => $this->ifUnset($pkg, 'distributor_url', 'http://dummy.org/'),
             'changelog'    => $this->ifEmpty($pkg, 'changelog', ''),
             'thirdparty'   => true,
             'category'     => 0,

--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -9,9 +9,11 @@ namespace SSpkS\Output;
 class JsonOutput
 {
     private $excludedServices = array();
+    private $config;
 
-    public function __construct()
+    public function __construct(\SSpkS\Config $config)
     {
+        $this->config = $config;
     }
 
     /**
@@ -35,13 +37,6 @@ class JsonOutput
     private function ifEmpty($obj, $property, $alternative = null)
     {
         if (isset($obj->$property) && !empty($obj->$property)) {
-            return $obj->$property;
-        }
-        return $alternative;
-    }
-    private function ifUnset($obj, $property, $alternative = null)
-    {
-        if (isset($obj->$property)) {
             return $obj->$property;
         }
         return $alternative;
@@ -121,10 +116,10 @@ auto_upgrade_from - version number (optional)
             'deppkgs'      => $deppkgs,
             'conflictpkgs' => null,
             'start'        => true,
-            'maintainer'      => $this->ifUnset($pkg, 'maintainer', 'SSpkS'),
-            'maintainer_url'  => $this->ifUnset($pkg, 'maintainer_url', 'http://dummy.org/'),
-            'distributor'     => $this->ifUnset($pkg, 'distributor', 'SSpkS'),
-            'distributor_url' => $this->ifUnset($pkg, 'distributor_url', 'http://dummy.org/'),
+            'maintainer'      => $this->ifEmpty($pkg, 'maintainer', $this->config->packages['maintainer']),
+            'maintainer_url'  => $this->ifEmpty($pkg, 'maintainer_url', $this->config->packages['maintainer_url']),
+            'distributor'     => $this->ifEmpty($pkg, 'distributor', $this->config->packages['distributor']),
+            'distributor_url' => $this->ifEmpty($pkg, 'distributor_url', $this->config->packages['distributor_url']),
             'changelog'    => $this->ifEmpty($pkg, 'changelog', ''),
             'thirdparty'   => true,
             'category'     => 0,

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -6,10 +6,12 @@ use PHPUnit\Framework\TestCase;
 use SSpkS\Package\Package;
 use SSpkS\Output\JsonOutput;
 use SSpkS\Output\UrlFixer;
+use SSpkS\Config;
 
 class JsonOutputTest extends TestCase
 {
     private $tempPkg;
+    private $goodFile = 'example_configs/sspks.yaml';
 
     public function setUp()
     {
@@ -36,7 +38,7 @@ class JsonOutputTest extends TestCase
         $uf = new UrlFixer('http://prefix');
         $uf->fixPackageList($pl);
 
-        $jo = new JsonOutput();
+        $jo = new JsonOutput(new Config(__DIR__, $this->goodFile));
         $jo->setExcludedServices(array('test3'));
 
         $jo->outputPackages($pl);
@@ -52,7 +54,7 @@ class JsonOutputTest extends TestCase
         $uf = new UrlFixer('http://prefix');
         $uf->fixPackageList($pl);
 
-        $jo = new JsonOutput();
+        $jo = new JsonOutput(new Config(__DIR__, $this->goodFile));
 
         $jo->outputPackages($pl);
 

--- a/tests/example_configs/sspks.yaml
+++ b/tests/example_configs/sspks.yaml
@@ -1,6 +1,12 @@
 site:
     name: Test config file
 
+packages:
+    maintainer:
+    maintainer_url:
+    distributor:
+    distributor_url:
+
 paths:
     models: tests/example_devicelists/models.yaml
     packages: tests/example_packageset/

--- a/tests/example_configs/sspks.yaml
+++ b/tests/example_configs/sspks.yaml
@@ -2,10 +2,10 @@ site:
     name: Test config file
 
 packages:
-    maintainer:
-    maintainer_url:
-    distributor:
-    distributor_url:
+    maintainer: SSpkS
+    maintainer_url: http://dummy.org/
+    distributor: SSpkS
+    distributor_url: http://dummy.org/
 
 paths:
     models: tests/example_devicelists/models.yaml


### PR DESCRIPTION
Hello,

This PR allows to set empty maintainer and distributor in INFO file, so that this info is not displayed in Packet Center.

Thank you 👍 

Ben