### PR TITLE
Add option to redirect index

### DIFF
--- a/conf/sspks.yaml
+++ b/conf/sspks.yaml
@@ -1,6 +1,7 @@
 site:
     name: Simple SPK Server
     theme: material
+    redirectindex:
 
 # ALL PATHS MUST BE RELATIVE TO THE ROOT
 # DIRECTORY (where the index.php is located)

--- a/conf/sspks.yaml
+++ b/conf/sspks.yaml
@@ -1,6 +1,8 @@
 site:
     name: Simple SPK Server
     theme: material
+    # If set, packet listing will be disabled
+    # and will redirect to the given URL
     redirectindex:
 
 # ALL PATHS MUST BE RELATIVE TO THE ROOT

--- a/lib/SSpkS/Handler.php
+++ b/lib/SSpkS/Handler.php
@@ -26,6 +26,9 @@ class Handler
 
         if (isset($_REQUEST['unique']) && substr($_REQUEST['unique'], 0, 8) == 'synology') {
             $handler = new SynologyHandler($this->config);
+        } elseif (isset($this->config->site['redirectindex']) && !empty($this->config->site['redirectindex'])) {
+            header('Location: '.$this->config->site['redirectindex']);
+            die();
         } elseif ($_SERVER['REQUEST_METHOD'] == 'GET') {
             // GET-request, probably browser --> show HTML
             $arch     = trim($_GET['arch']);


### PR DESCRIPTION
Hello,

This PR adds a new option `redirectindex` which allows to redirect packet listing to another URL (if we don't want to enable the packet listing).

Thank you 👍 

Ben