### PR TITLE
Locales support for packages display name and description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /cache/*.png
 /packages/*.spk
 /vendor/*
+/.idea/

--- a/lib/SSpkS/Handler/SynologyHandler.php
+++ b/lib/SSpkS/Handler/SynologyHandler.php
@@ -44,7 +44,11 @@ class SynologyHandler extends AbstractHandler
         $minor    = trim($_REQUEST['minor']);
         $build    = trim($_REQUEST['build']);
         $channel  = trim($_REQUEST['package_update_channel']);
-        // more parameters: language, timezone and unique
+        if (isset($_REQUEST['language']))
+            $language = trim($_REQUEST['language']);
+        else
+            $language = '';
+        // more parameters: timezone and unique
 
         if ($arch == '88f6282') {
             $arch = '88f6281';
@@ -66,6 +70,6 @@ class SynologyHandler extends AbstractHandler
 
         $jo = new JsonOutput($this->config);
         $jo->setExcludedServices($this->config->excludedSynoServices);
-        $jo->outputPackages($filteredPkgList);
+        $jo->outputPackages($filteredPkgList, $language);
     }
 }

--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -99,8 +99,8 @@ auto_upgrade_from - version number (optional)
         $packageJSON = array(
             'package'      => $pkg->package,
             'version'      => $pkg->version,
-            'dname'        => $this->ifEmpty($pkg, "displayname_$language", $pkg->displayname),
-            'desc'         => $this->ifEmpty($pkg, "description_$language", $pkg->description),
+            'dname'        => $this->ifEmpty($pkg, 'displayname_' . $language, $pkg->displayname),
+            'desc'         => $this->ifEmpty($pkg, 'description_' . $language, $pkg->description),
             'price'        => 0,
             'download_count'        => 0, // Will only display values over 1000, do not display it by default
             'recent_download_count' => 0,

--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -46,9 +46,10 @@ class JsonOutput
      * Returns JSON-ready array of Package $pkg.
      *
      * @param \SSpkS\Package\Package $pkg Package
+     * @param string $language The output language (this has impact on display name and description)
      * @return array JSON-ready array of $pkg.
      */
-    private function packageToJson($pkg)
+    private function packageToJson($pkg, $language)
     {
 /*
 package
@@ -98,8 +99,8 @@ auto_upgrade_from - version number (optional)
         $packageJSON = array(
             'package'      => $pkg->package,
             'version'      => $pkg->version,
-            'dname'        => $pkg->displayname,
-            'desc'         => $pkg->description,
+            'dname'        => $this->ifEmpty($pkg, "displayname_$language", $pkg->displayname),
+            'desc'         => $this->ifEmpty($pkg, "description_$language", $pkg->description),
             'price'        => 0,
             'download_count'        => 0, // Will only display values over 1000, do not display it by default
             'recent_download_count' => 0,
@@ -137,14 +138,15 @@ auto_upgrade_from - version number (optional)
      * Outputs given packages as JSON.
      *
      * @param \SSpkS\Package\Package[] $pkgList List of packages to output.
+     * @param string $language The output language (this has impact on display name and description)
      */
-    public function outputPackages($pkgList)
+    public function outputPackages($pkgList, $language)
     {
         $jsonOutput = array(
             'packages' => array(),
         );
         foreach ($pkgList as $pkg) {
-            $pkgJson = $this->packageToJson($pkg);
+            $pkgJson = $this->packageToJson($pkg, $language);
             $jsonOutput['packages'][] = $pkgJson;
         }
 

--- a/lib/SSpkS/Output/JsonOutput.php
+++ b/lib/SSpkS/Output/JsonOutput.php
@@ -140,7 +140,7 @@ auto_upgrade_from - version number (optional)
      * @param \SSpkS\Package\Package[] $pkgList List of packages to output.
      * @param string $language The output language (this has impact on display name and description)
      */
-    public function outputPackages($pkgList, $language)
+    public function outputPackages($pkgList, $language = 'enu')
     {
         $jsonOutput = array(
             'packages' => array(),

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -46,7 +46,7 @@ class JsonOutputTest extends TestCase
         $jo = new JsonOutput($this->config);
         $jo->setExcludedServices(array('test3'));
 
-        $jo->outputPackages($pl);
+        $jo->outputPackages($pl, null);
 
         $this->expectOutputRegex('/"deppkgs":"test1 test2  test4"/');
     }
@@ -61,7 +61,7 @@ class JsonOutputTest extends TestCase
 
         $jo = new JsonOutput($this->config);
 
-        $jo->outputPackages($pl);
+        $jo->outputPackages($pl, null);
 
         $pkgMd5  = md5_file($this->tempPkg);
         $pkgSize = filesize($this->tempPkg);


### PR DESCRIPTION
This small change uses the language query parameter to return the display name and description in requested language, if available (otherwise it defaults to defaults... :wink:)
