### PR TITLE
Filtering differently on DSM <7 and >=7

### DIFF
--- a/lib/SSpkS/Package/PackageFilter.php
+++ b/lib/SSpkS/Package/PackageFilter.php
@@ -100,12 +100,27 @@ class PackageFilter
      * @param \SSpkS\Package\Package $package Package to test.
      * @return bool TRUE if matching, or FALSE.
      */
-    public function isMatchingFirmwareVersion($package)
+    public function isMatchingFirmwareVersion(\SSpkS\Package\Package $package): bool
     {
         if ($this->filterFwVersion === false) {
             return true;
         }
-        return (version_compare($package->firmware, /** @scrutinizer ignore-type */ $this->filterFwVersion, '<='));
+        if(version_compare(/** @scrutinizer ignore-type */ $this->filterFwVersion, '7', '<'))
+            return $this->isMatchingFirmwareVersionPre7($package);
+        return $this->isMatchingFirmwareVersionPost7($package);
+    }
+
+    private function isMatchingFirmwareVersionPre7(\SSpkS\Package\Package $package): bool
+    {
+        // on DSM6 or less, package must be <= to filter
+        return version_compare($package->firmware, /** @scrutinizer ignore-type */ $this->filterFwVersion, '<=');
+    }
+
+    private function isMatchingFirmwareVersionPost7(\SSpkS\Package\Package $package): bool
+    {
+        // on DSM7 or above (hypothetically), package must be <= to filter
+        return version_compare($package->firmware, /** @scrutinizer ignore-type */ '7', '>=')
+        && version_compare($package->firmware, /** @scrutinizer ignore-type */ $this->filterFwVersion, '<=');
     }
 
     /**

--- a/tests/PackageFilterTest.php
+++ b/tests/PackageFilterTest.php
@@ -73,6 +73,9 @@ class PackageFilterTest extends TestCase
         $pf->setFirmwareVersionFilter('1.0-1234');
         $newList = $pf->getFilteredPackageList();
         $this->assertCount(5, $newList);
+        $pf->setFirmwareVersionFilter('7.0-40000');
+        $newList = $pf->getFilteredPackageList();
+        $this->assertCount(0, $newList);
     }
 
     public function testChannelFilter()


### PR DESCRIPTION
As stated in issue #82, packages written for DSM 6 are not compatible with DSM 7:
- DSM 7 packages must be marked with `os_min_ver` > 7.0
- This maker DSM 7 package incompatible with DSM 6

So filtering has to work with two different platforms:
- DSM <= 6
- DSM >= 7
