### PR TITLE
Better DSM 7 support

### DIFF
--- a/lib/SSpkS/Package/Package.php
+++ b/lib/SSpkS/Package/Package.php
@@ -15,7 +15,7 @@ namespace SSpkS\Package;
  * @property string $maintainer_url URL of maintainer's web page
  * @property string $distributor Package distributor
  * @property string $distributor_url URL of distributor's web page
- * @property string $support_url URL of support web page
+ * @property string $support_url URL of support web page 
  * @property array $arch List of supported architectures, or 'noarch'
  * @property array $thumbnail List of thumbnail files
  * @property array $thumbnail_url List of thumbnail URLs
@@ -171,6 +171,10 @@ class Package
         $this->metadata['qinst'] = !empty($this->metadata['qinst']) ? $this->parseBool($this->metadata['qinst']) : $qValue;
         $this->metadata['qupgrade'] = !empty($this->metadata['qupgrade']) ? $this->parseBool($this->metadata['qupgrade']) : $qValue;
         $this->metadata['qstart'] = !empty($this->metadata['qstart']) ? $this->parseBool($this->metadata['qstart']) : $qValue;
+        
+        if (isset($this->metadata['os_min_ver'])) {
+           $this->metadata['firmware'] = $this->metadata['os_min_ver'];
+        }
     }
 
     /**

--- a/lib/SSpkS/Package/PackageFilter.php
+++ b/lib/SSpkS/Package/PackageFilter.php
@@ -113,7 +113,8 @@ class PackageFilter
     private function isMatchingFirmwareVersionPre7(\SSpkS\Package\Package $package): bool
     {
         // on DSM6 or less, package must be <= to filter
-        return version_compare($package->firmware, /** @scrutinizer ignore-type */ $this->filterFwVersion, '<=');
+        return version_compare($package->firmware, /** @scrutinizer ignore-type */ '7', '<')
+        && version_compare($package->firmware, /** @scrutinizer ignore-type */ $this->filterFwVersion, '<=');
     }
 
     private function isMatchingFirmwareVersionPost7(\SSpkS\Package\Package $package): bool


### PR DESCRIPTION
Support os_min_ver instead of obsolete firmware.
Do not deliver DSM 7 package to DSM 6 machine.