### PR TITLE
Better DSM7 compatibility

### DIFF
--- a/conf/sspks.yaml
+++ b/conf/sspks.yaml
@@ -25,6 +25,7 @@ paths:
 excludedSynoServices:
     - apache-sys
     - apache-web
+    - mysql
     - mdns
     - samba
     - db

--- a/lib/SSpkS/Output/JsonOutput.php.bak
+++ b/lib/SSpkS/Output/JsonOutput.php.bak
@@ -96,9 +96,6 @@ class JsonOutput
         } else {
             $deppkgs = null;
         }
-        if ($deppkgs == "") {
-            $deppkgs = null;
-        }
 
         $packageJSON = array(
             'package' => $pkg->package,


### PR DESCRIPTION
If no depency's are left, pass null as json output
Add mysql to dependency exception list.